### PR TITLE
Share Page in New UI

### DIFF
--- a/app/routes/project/share.py
+++ b/app/routes/project/share.py
@@ -22,7 +22,7 @@ def share(project_id):
     is_owner = user_is_project_owner(session["user_id"], project_id)
 
     def render(error=""):
-        return render_template("project/share.html", 
+        return render_template("project/share.html.j2", 
                 authorized_users=authorized_users, 
                 is_owner=is_owner,
                 error=error,
@@ -40,7 +40,7 @@ def share(project_id):
         if not user:
             return render("Error: User not found.")
         elif user.id == session['user_id']:
-            return render("Why are you trying to change your own permissions? What a chud.")
+            return render("You shouldn't change your own permissions.")
 
         existing_role = db.session.query(Role).filter(
             and_(

--- a/app/static/css/components/modal.css
+++ b/app/static/css/components/modal.css
@@ -19,10 +19,24 @@
   border-radius: 10px;
   width: 20%; /* Could be more or less, depending on screen size */
 }
+.modal-content.warning {
+  background-color: var(--color-danger-bg-soft);
+  border-color: var(--color-danger-border);
+  color: var(--color-danger);
+}
+.modal-button {
+  text-align: center;
+}
+.modal-content.warning > .modal-button > button {
+  background-color: var(--color-danger);
+}
 
 .modal-header {
-    font-weight: bold;
-    font-size: 125%;
+  font-weight: bold;
+  font-size: 125%;
+}
+.modal-header.warning {
+  text-align: center;
 }
 
 .close {
@@ -31,10 +45,17 @@
   font-size: 28px;
   font-weight: bold;
 }
+.close.warning {
+  color: var(--color-danger-border);
+}
 
 .close:hover,
 .close:focus {
   color: var(--color-text-primary);
   text-decoration: none;
   cursor: pointer;
+}
+.close.warning:hover,
+.close.warning:focus {
+  color: var(--color-danger);
 }

--- a/app/static/css/pages/project/share.css
+++ b/app/static/css/pages/project/share.css
@@ -1,0 +1,33 @@
+.manage-permission-section { 
+    margin-top: var(--space-md);
+}
+
+.user-permission-table {
+    border-collapse: collapse;
+    width: 50%;
+    background-color: var(--color-bg);
+    padding: var(--space-lg);
+}
+
+th, td {
+    border: 1px solid var(--color-border);
+    padding: var(--space-sm);
+    text-align: left;
+}
+
+th {
+    background-color: var(--color-accent);
+    color: var(--color-bg);
+}
+
+tr:nth-child(even) {
+    background-color: var(--color-surface);
+}
+
+.share-form {
+    width: 30%;
+}
+form > #modal-btn {
+    margin-top: auto;
+    width: fit-content;
+}

--- a/app/static/js/components/modal.js
+++ b/app/static/js/components/modal.js
@@ -1,10 +1,10 @@
-var modal = document.getElementById("modal");
+const modal = document.getElementById("modal");
 
 // Get the button that opens the modal
-var btn = document.getElementById("modal-btn");
+const btn = document.getElementById("modal-btn");
 
 // Get the <span> element that closes the modal
-var span = document.getElementsByClassName("close")[0];
+const span = document.getElementsByClassName("close")[0];
 
 // When the user clicks on the button, open the modal
 btn.onclick = function() {

--- a/app/static/js/pages/share-modal.js
+++ b/app/static/js/pages/share-modal.js
@@ -1,0 +1,39 @@
+const modal = document.getElementById("modal");
+
+// Get the button that opens the modal
+const btn = document.getElementById("modal-btn");
+
+// Get the <span> element that closes the modal
+const span = document.getElementsByClassName("close")[0];
+
+const dependent_form_element = document.getElementById("permission-select");
+const form_in_question = document.getElementById("share-form");
+
+const username_error = document.getElementById("username-error");
+
+// When the user clicks on the button, open the modal
+btn.onclick = function() {
+  var selectedOption = dependent_form_element.options[dependent_form_element.selectedIndex].text;
+  let usernameValue = form_in_question["username"].value;
+
+  const usernameValid = usernameValue.length >= 3;
+
+  if (selectedOption === "Owner" && usernameValid) {
+    modal.style.display = "block";
+  } else if (usernameValid) {
+    form_in_question.submit();
+  } else {
+    username_error.style.display = "block";
+  }
+}
+
+// When the user clicks on <span> (x), close the modal
+span.onclick = function() {
+  modal.style.display = "none";
+}
+
+window.onclick = function(event) {
+  if (event.target == modal) {
+    modal.style.display = "none";
+  }
+}

--- a/app/templates/base/dashboard.html.j2
+++ b/app/templates/base/dashboard.html.j2
@@ -165,6 +165,10 @@
                                     <i class="bi bi-cash-stack sidebar-link-icon" aria-hidden="true"></i>
                                     <span class="sidebar-link-text">Finance</span>
                                 </a>
+                                <a href="{{ url_for('project.share', project_id=current_project_id) }}" class="sidebar-link{% if request.endpoint == 'project.share' %} active{% endif %}">
+                                    <i class="bi bi-share sidebar-link-icon" aria-hidden="true"></i>
+                                    <span class="sidebar-link-text">Share</span>
+                                </a>
                                 <a href="{{ url_for('project.settings', project_id=current_project_id) }}" class="sidebar-link{% if request.endpoint == 'project.settings' %} active{% endif %}">
                                     <i class="bi bi-sliders sidebar-link-icon" aria-hidden="true"></i>
                                     <span class="sidebar-link-text">Settings</span>

--- a/app/templates/project/people.html.j2
+++ b/app/templates/project/people.html.j2
@@ -92,7 +92,6 @@
                 <p class="section-empty-text">No people assigned yet.</p>
             {% endif %}
         </section>
-
     </div>
 
 {% endblock %}

--- a/app/templates/project/share.html.j2
+++ b/app/templates/project/share.html.j2
@@ -1,0 +1,106 @@
+{% extends "base/dashboard.html.j2" %}
+
+{% block title %}
+    Pandata | {{ active_project.title }} - Share
+{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/pages/project/share.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/components/modal.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/pages/project/home.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/pages/project/project-form.css') }}">
+{% endblock %}
+
+{% block page_header %}
+    <h1>Share</h1>
+    <p class="page-subtitle">Manage project user permissions.</p>
+    <p class="page-subtitle">Only project <strong>Owners</strong> can manage project permissions.</p>
+{% endblock %}
+
+{% block page_header_actions %}
+    <a href="{{ url_for('project.home', project_id=active_project_id) }}" class="button-secondary">← Back</a>
+{% endblock %}
+
+{% block main_content %}
+<section class="project-section">
+    <div class="section-header">
+        <h2>Users with Access:</h2>
+    </div>
+    <table class="user-permission-table">
+        <thead>
+            <tr>
+                <th>Username</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Access Level</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for user in authorized_users %}
+            <tr>
+                <td>{{ user[0].username }}</td>
+                <td>{{ user[0].full_name }}</td>
+                <td>{{ user[0].email }}</td>
+                <td>{{ user[1].capitalize() }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </section>
+
+    <section class="project-section manage-permission-section">
+    {% if is_owner %}
+    <div class="section-header">
+        <h2>Grant or Change Access</h2>
+    </div>
+    <form method="POST" class="project-form share-form" id="share-form" action="{{ url_for('project.share', project_id=active_project_id) }}">
+        <div class="form-section">
+            <input class="form-input"
+                   type="text" 
+                   id="username" 
+                   name="username" 
+                   minlength="3" 
+                   maxlength="25" 
+                   autocomplete="off"
+                   placeholder="Username..."
+                   required>
+        </div>
+        <div class="form-section">
+            <select class="form-input" id="permission-select" aria-label="Level of Access" name="role" required>
+                <option value="viewer" title="Viewers can not edit projects.">Viewer</option>
+                <option value="editor" title="Editors can edit project data.">Editor</option>
+                <option value="remove" title="Remove user access to project.">Remove</option>
+                <option value="owner" title="Owners have admin access to projects.">Owner</option>
+            </select>
+        </div>
+        <div class="form-alert error" style="display: none;" id="username-error" role="alert">
+            Please input valid username.
+        </div>
+        {% if error %}
+            <div class="form-alert error" role="alert">
+                {{ error }}
+            </div>
+        {% endif %}
+        <p id="modal-btn" class="button">Submit</p>
+        <div id="modal" class="modal">
+            <div class="modal-content warning">
+                <span class="close warning">&times;</span>
+                <h2 class="modal-header warning">WARNING!</h2>
+                <p>Giving another user project ownership permissions grants them total control over a project.</p>
+                <p>This means they could delete the project, or remove your ownership permissions.</p>
+                <p>Only give this permission to completely trustworthy users.</p>
+                <div class="modal-button">
+                    <button type="submit" class="button">I know what I'm doing</button>
+                </div>
+            </div>
+        </div>
+    </form>
+
+
+    {% endif %}
+</section>
+{% endblock %}
+
+{% block extra_js %}
+    <script src="{{ url_for('static', filename='js/pages/share-modal.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
Ported share page to new UI

Changed share page functionality: 
- Users can now give other users ownership permissions over a project
- When this is attempted, a warning modal pops up to ensure the user knows what they're doing, since owners can change sharing permissions (i.e. user 1 could give user 2 ownership permissions which they could use to revoke user 1's permissions)

I did my best to make the UI match the new style, and used predefined CSS where applicable.